### PR TITLE
Made the false positive homosexual singular

### DIFF
--- a/src/false_positives.txt
+++ b/src/false_positives.txt
@@ -3991,7 +3991,7 @@ homosexualism
 homosexualist
 homosexuality
 homosexually
-homosexuals
+homosexual
 homosphere
 homosporous
 homospory


### PR DESCRIPTION
As this world can be used in its singular form in normal discussion without derogatory meaning, it should probably be in the in the false positive list as a singular word.